### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
 name: Go tests
 on: [push]
+permissions:
+  contents: read
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/gentlecat/publisher/security/code-scanning/1](https://github.com/gentlecat/publisher/security/code-scanning/1)

To fix this problem, you should explicitly add a `permissions` block to the workflow. This can be added at the workflow (YAML root) level or per-job. For workflows that only need to check out code and run local tests (as in this case), the minimal, recommended permission is `contents: read`. This limitation ensures the workflow's GITHUB_TOKEN can only read repository contents and cannot make changes or access more privileged scopes than necessary.  
The block should be added directly below the `name` or `on` lines at the root of the YAML file.


---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
